### PR TITLE
마이그레이션 브릿지: 기존 Gatsby 서비스워커 자동 정리

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,5 @@
+/sw.js
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+  Service-Worker-Allowed: /

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,0 +1,45 @@
+/* 
+ * Transitional service worker for Gatsby -> React Router migration.
+ * Existing clients already scoped to /sw.js will receive this file,
+ * clear old caches, then unregister.
+ */
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+async function clearAllCaches() {
+  const cacheNames = await caches.keys();
+  await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+}
+
+async function refreshClients() {
+  const clients = await self.clients.matchAll({
+    type: "window",
+    includeUncontrolled: true,
+  });
+
+  await Promise.all(
+    clients.map(async (client) => {
+      client.postMessage({ type: "SW_CLEANUP_COMPLETE" });
+
+      if (typeof client.navigate === "function") {
+        try {
+          await client.navigate(client.url);
+        } catch {
+          // Ignore navigation failures (for example, if the tab is closing).
+        }
+      }
+    })
+  );
+}
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      await clearAllCaches();
+      await self.registration.unregister();
+      await refreshClients();
+    })()
+  );
+});


### PR DESCRIPTION
## 변경 내용
- `static/sw.js`에 **브릿지용 정리 서비스워커**를 추가했습니다.
  - 기존 Gatsby 사용자(이미 `/sw.js`를 등록한 브라우저)가 새 배포를 받으면, `install/activate` 단계에서 즉시 동작합니다.
  - Cache Storage를 전부 정리하고, 현재 서비스워커를 `unregister` 합니다.
  - 열려 있는 탭은 `client.navigate(client.url)`를 시도해 새 네트워크 컨텐츠를 다시 받도록 유도합니다.
- `static/_headers`를 추가해 `/sw.js` 캐싱을 강제로 비활성화했습니다.
  - `Cache-Control: no-cache, no-store, must-revalidate`
  - `Pragma: no-cache`
  - `Expires: 0`
  - `Service-Worker-Allowed: /`

## 기대 효과
- 기존 서비스워커가 남아 있는 사용자도 **별도 조치 없이** 정리 SW를 통해 자동 전환됩니다.
- 전환 완료 후 트래픽은 React Router v7 산출물로 수렴합니다.

## 검증
- `corepack yarn build` 성공
- 빌드 산출물 포함 확인
  - `build/client/sw.js`
  - `build/client/_headers`


---

## 추가 변경 (Husky 재도입)
- Husky 최신 버전(`9.1.7`)과 lint-staged(`16.2.7`)를 재도입했습니다.
- `lint-staged.config.mjs`를 추가해 staged 파일 기준 타입체크를 수행합니다.
- `.husky/pre-commit`을 Husky v9 포맷으로 갱신했습니다(기존 deprecate 패턴 제거).
- `postinstall`에서 `scripts/setup-husky.mjs`를 실행해 hooksPath를 자동 설치하도록 했습니다.

### Yarn 1/4 및 CI 고려사항
- 훅 실행 자체는 `npm run lint-staged` 경로를 사용해 Yarn 1/4 차이에 덜 민감하게 구성했습니다.
- Husky 설치 스크립트는 `CI`, `NETLIFY`, `HUSKY=0` 환경에서는 자동 스킵되어 배포 환경에 영향을 주지 않습니다.
