### PR TITLE
Improve blog payload and cache behavior

### DIFF
--- a/app/components/ArticleList/index.tsx
+++ b/app/components/ArticleList/index.tsx
@@ -1,12 +1,12 @@
 import { memo } from "react";
 
-import type { Post } from "~/lib/post-types";
+import type { PostSummary } from "~/lib/post-types";
 import ArticleListItem from "~/components/ArticleList/Item";
 
 import * as styles from "./styles.css";
 
 interface Props {
-  posts: Post[];
+  posts: PostSummary[];
 }
 
 const ArticleList = ({ posts }: Props) => {

--- a/app/fonts/Pretendard/pretendard.css
+++ b/app/fonts/Pretendard/pretendard.css
@@ -1,62 +1,23 @@
 @font-face {
-    font-weight: 900;
-    font-family: 'Pretendard';
-    font-display: swap;
-    src: local('Pretendard Black'), url('./woff2/Pretendard-Black.woff2') format('woff2'), url('./woff/Pretendard-Black.woff') format('woff');
+  font-family: "Pretendard";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local("Pretendard Regular"), url("./woff2/Pretendard-Regular.woff2") format("woff2");
 }
 
 @font-face {
-    font-weight: 800;
-    font-family: 'Pretendard';
-    font-display: swap;
-    src: local('Pretendard ExtraBold'), url('./woff2/Pretendard-ExtraBold.woff2') format('woff2'), url('./woff/Pretendard-ExtraBold.woff') format('woff');
+  font-family: "Pretendard";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local("Pretendard Bold"), url("./woff2/Pretendard-Bold.woff2") format("woff2");
 }
 
 @font-face {
-    font-weight: 700;
-    font-family: 'Pretendard';
-    font-display: swap;
-    src: local('Pretendard Bold'), url('./woff2/Pretendard-Bold.woff2') format('woff2'), url('./woff/Pretendard-Bold.woff') format('woff');
-}
-
-@font-face {
-    font-weight: 600;
-    font-family: 'Pretendard';
-    font-display: swap;
-    src: local('Pretendard SemiBold'), url('./woff2/Pretendard-SemiBold.woff2') format('woff2'), url('./woff/Pretendard-SemiBold.woff') format('woff');
-}
-
-@font-face {
-    font-weight: 500;
-    font-family: 'Pretendard';
-    font-display: swap;
-    src: local('Pretendard Medium'), url('./woff2/Pretendard-Medium.woff2') format('woff2'), url('./woff/Pretendard-Medium.woff') format('woff');
-}
-
-@font-face {
-    font-weight: 400;
-    font-family: 'Pretendard';
-    font-display: swap;
-    src: local('Pretendard Regular'), url('./woff2/Pretendard-Regular.woff2') format('woff2'), url('./woff/Pretendard-Regular.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'Pretendard';
-    font-weight: 300;
-    font-display: swap;
-    src: local('Pretendard Light'), url('./woff2/Pretendard-Light.woff2') format('woff2'), url('./woff/Pretendard-Light.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'Pretendard';
-    font-weight: 200;
-    font-display: swap;
-    src: local('Pretendard ExtraLight'), url('./woff2/Pretendard-ExtraLight.woff2') format('woff2'), url('./woff/Pretendard-ExtraLight.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'Pretendard';
-    font-weight: 100;
-    font-display: swap;
-    src: local('Pretendard Thin'), url('./woff2/Pretendard-Thin.woff2') format('woff2'), url('./woff/Pretendard-Thin.woff') format('woff');
+  font-family: "Pretendard";
+  font-style: normal;
+  font-weight: 900;
+  font-display: swap;
+  src: local("Pretendard Black"), url("./woff2/Pretendard-Black.woff2") format("woff2");
 }

--- a/app/lib/post-summaries.ts
+++ b/app/lib/post-summaries.ts
@@ -1,0 +1,8 @@
+import rawPostSummaries from "~/generated/post-summaries.json";
+import type { PostSummary } from "~/lib/post-types";
+
+const parsedPostSummaries = (rawPostSummaries as PostSummary[])
+  .filter((post) => !post.draft)
+  .sort((firstPost, secondPost) => secondPost.date.localeCompare(firstPost.date));
+
+export const allPostSummaries = parsedPostSummaries;

--- a/app/lib/post-types.ts
+++ b/app/lib/post-types.ts
@@ -13,3 +13,5 @@ export type Post = {
   html: string;
   tableOfContents: string;
 };
+
+export type PostSummary = Omit<Post, "html" | "tableOfContents">;

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useRef } from "react";
+import { useLoaderData } from "react-router";
 
 import ArticleList from "~/components/ArticleList";
 import Profile from "~/components/Profile";
 import { useInfiniteScroll } from "~/hooks/useInfiniteScroll";
 import { usePage } from "~/hooks/usePage";
-import { allPosts } from "~/lib/posts";
+import { allPostSummaries } from "~/lib/post-summaries";
 import siteConfig from "~/lib/site-config";
 import Layout from "~/layout";
 
@@ -48,10 +49,16 @@ export function meta() {
   return meta;
 }
 
+export function loader() {
+  return {
+    posts: allPostSummaries,
+  };
+}
+
 export default function Home() {
   const infiniteScrollRef = useRef<HTMLDivElement | null>(null);
   const [page, setPage] = usePage();
-  const posts = allPosts;
+  const { posts } = useLoaderData<typeof loader>();
 
   const totalPage = Math.max(1, Math.ceil(posts.length / articlePerPage));
 

--- a/scripts/generate-content.mjs
+++ b/scripts/generate-content.mjs
@@ -304,9 +304,15 @@ async function main() {
   }
 
   posts.sort((a, b) => b.date.localeCompare(a.date));
+  const postSummaries = posts.map(({ html, tableOfContents, ...summary }) => summary);
 
   await fs.mkdir(GENERATED_DIR, { recursive: true });
   await fs.writeFile(path.join(GENERATED_DIR, "posts.json"), `${JSON.stringify(posts, null, 2)}\n`, "utf8");
+  await fs.writeFile(
+    path.join(GENERATED_DIR, "post-summaries.json"),
+    `${JSON.stringify(postSummaries, null, 2)}\n`,
+    "utf8"
+  );
 
   await copyDir(STATIC_DIR, PUBLIC_DIR);
   await copyDir(BLOG_DIR, PUBLIC_BLOG_ASSET_DIR, (filePath) => !filePath.toLowerCase().endsWith(".md"));

--- a/static/_headers
+++ b/static/_headers
@@ -1,3 +1,15 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/content/blog/*
+  Cache-Control: public, max-age=604800, stale-while-revalidate=86400
+
+/*.data
+  Cache-Control: public, max-age=300, stale-while-revalidate=86400
+
+/*
+  Cache-Control: public, max-age=0, must-revalidate
+
 /sw.js
   Cache-Control: no-cache, no-store, must-revalidate
   Pragma: no-cache


### PR DESCRIPTION
## Summary
- split generated post data into summaries for home list and full content for post pages
- reduce Pretendard font payload to used weights in woff2
- add Netlify cache headers for assets, blog content, and .data files

## Validation
- corepack yarn build
- corepack yarn typecheck