### PR TITLE
fix: 포스트 이동 시 댓글 thread 동기화

### DIFF
--- a/app/components/Utterances/index.tsx
+++ b/app/components/Utterances/index.tsx
@@ -7,9 +7,10 @@ const branch = "main";
 
 interface Props {
   repo: string;
+  pathname: string;
 }
 
-const Utterances = ({ repo }: Props) => {
+const Utterances = ({ repo, pathname }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
 
   const [darkMode] = useDarkMode();
@@ -25,7 +26,7 @@ const Utterances = ({ repo }: Props) => {
       label: "comment",
       async: "true",
       crossorigin: "anonymous",
-      "issue-term": "pathname",
+      "issue-term": pathname,
     };
 
     Object.entries(config).forEach(([key, value]) => {
@@ -38,7 +39,7 @@ const Utterances = ({ repo }: Props) => {
 
     ref.current.innerHTML = "";
     ref.current.appendChild(utterances);
-  }, [repo, utteranceTheme]);
+  }, [repo, pathname, utteranceTheme]);
 
   return <div className="utterances" ref={ref} />;
 };

--- a/app/routes/post.tsx
+++ b/app/routes/post.tsx
@@ -116,7 +116,7 @@ export default function PostRoute({ loaderData }: Route.ComponentProps) {
         </footer>
       </article>
 
-      {commentConfig?.utterances ? <Utterances repo={commentConfig.utterances} /> : null}
+      {commentConfig?.utterances ? <Utterances repo={commentConfig.utterances} pathname={post.path} /> : null}
 
       <ArticleNavigator previousArticle={previousPost} nextArticle={nextPost} />
     </Layout>


### PR DESCRIPTION
## 목적
- 포스트 상세 하단의 이전/이후 이동 시 댓글 영역이 현재 포스트를 정확히 가리키도록 수정합니다.

## 배경
- 현재 증상/리스크:
  - 포스트 간 이동 후에도 Utterances가 이전 포스트 thread를 유지하는 경우가 있습니다.
- 원인 또는 가설:
  - 댓글 스크립트 재초기화 `useEffect`가 `repo/theme`만 의존하고, 포스트 경로(`pathname`) 변경을 감지하지 못했습니다.
- 기대 효과:
  - 상세 라우트 전환마다 댓글 thread가 현재 포스트 기준으로 일관되게 갱신됩니다.

## 변경 내용
- `app/components/Utterances/index.tsx`
  - `pathname` prop 추가
  - `useEffect` 의존성에 `pathname` 추가
  - `issue-term` 값을 현재 포스트 `pathname`으로 전달
- `app/routes/post.tsx`
  - `Utterances`에 `pathname={post.path}` 전달

## 영향 범위
- 사용자 영향:
  - 포스트 네비게이션 후 댓글 대상 불일치 문제 해결
- 운영/배포 영향:
  - 없음
- 성능/보안 영향:
  - 없음

## 검증
- 로컬 검증:
  - `corepack yarn typecheck` 통과
  - `corepack yarn build` 통과
- 수동 확인:
  - 포스트 상세에서 이전/이후 링크 이동 시 댓글 thread가 현재 포스트 기준으로 변경됨

## 체크리스트
- [x] 회귀 가능성이 있는 경로를 점검했다.
- [x] 문서/설정 변경이 필요한 경우 반영했다.
- [x] 배포 후 모니터링 포인트를 확인했다.
