### PR TITLE
feat: Obsidian 수정 후 원격 PR 자동 트리거 워크플로우 추가

### DIFF
--- a/.github/workflows/obsidian-sync-pr.yml
+++ b/.github/workflows/obsidian-sync-pr.yml
@@ -1,0 +1,133 @@
+name: Obsidian Sync PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: "Obsidian 소스 폴더 (vault 기준 상대경로)"
+        required: false
+        default: "Publish/Fleeting"
+      prune:
+        description: "소스에서 삭제된 노트도 블로그에서 제거"
+        required: false
+        type: boolean
+        default: false
+      title:
+        description: "PR 제목(비우면 자동)"
+        required: false
+  repository_dispatch:
+    types:
+      - obsidian_sync
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: obsidian-sync-pr
+  cancel-in-progress: false
+
+jobs:
+  sync-and-pr:
+    runs-on:
+      - self-hosted
+      - macOS
+    env:
+      OBSIDIAN_VAULT_PATH: ${{ vars.OBSIDIAN_VAULT_PATH }}
+      DEFAULT_SOURCE: ${{ vars.OBSIDIAN_FLEETING_DIR }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: corepack yarn install --immutable
+
+      - name: Resolve options
+        id: opts
+        shell: bash
+        env:
+          WORKFLOW_SOURCE: ${{ github.event.inputs.source || '' }}
+          WORKFLOW_PRUNE: ${{ github.event.inputs.prune || '' }}
+          WORKFLOW_TITLE: ${{ github.event.inputs.title || '' }}
+          DISPATCH_SOURCE: ${{ github.event.client_payload.source || '' }}
+          DISPATCH_PRUNE: ${{ github.event.client_payload.prune || '' }}
+          DISPATCH_TITLE: ${{ github.event.client_payload.title || '' }}
+        run: |
+          source_value="$WORKFLOW_SOURCE"
+          prune_value="$WORKFLOW_PRUNE"
+          title_value="$WORKFLOW_TITLE"
+
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            source_value="$DISPATCH_SOURCE"
+            prune_value="$DISPATCH_PRUNE"
+            title_value="$DISPATCH_TITLE"
+          fi
+
+          if [ -z "$source_value" ]; then
+            if [ -n "$DEFAULT_SOURCE" ]; then
+              source_value="$DEFAULT_SOURCE"
+            else
+              source_value="Publish/Fleeting"
+            fi
+          fi
+
+          if [ -z "$prune_value" ]; then
+            prune_value="false"
+          fi
+
+          if [ -z "$title_value" ]; then
+            title_value="chore: Obsidian fleeting 동기화 ($(date +%F))"
+          fi
+
+          echo "source=$source_value" >> "$GITHUB_OUTPUT"
+          echo "prune=$prune_value" >> "$GITHUB_OUTPUT"
+          echo "title=$title_value" >> "$GITHUB_OUTPUT"
+
+      - name: Sync from Obsidian
+        shell: bash
+        run: |
+          args=(--source "${{ steps.opts.outputs.source }}")
+          if [ "${{ steps.opts.outputs.prune }}" = "true" ]; then
+            args+=(--prune)
+          fi
+          node ./scripts/sync-obsidian-fleeting.mjs "${args[@]}"
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: ${{ steps.opts.outputs.title }}
+          title: ${{ steps.opts.outputs.title }}
+          body: |
+            ## 배경
+            - 모바일 Obsidian 작성 후 원격에서 바로 동기화/PR을 만들기 위한 자동화 실행 결과입니다.
+
+            ## 변경 사항
+            - Obsidian 노트를 `content/blog/fleeting`로 동기화했습니다.
+
+            ## 체크리스트
+            - [x] 동기화 결과 확인
+            - [ ] 리뷰 및 머지
+          branch: codex/obsidian-sync
+          branch-suffix: timestamp
+          base: main
+          add-paths: |
+            content/blog/fleeting/**
+          delete-branch: true
+
+      - name: Summary
+        shell: bash
+        run: |
+          if [ -n "${{ steps.cpr.outputs.pull-request-url }}" ]; then
+            echo "PR created: ${{ steps.cpr.outputs.pull-request-url }}"
+          else
+            echo "No content changes. PR was not created."
+          fi

--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ yarn sync:obsidian:pr -- --no-pr
 - 변경하려면 `OBSIDIAN_FLEETING_DIR` 또는 `--source` 사용
 - `sync:obsidian:pr`는 `gh` CLI 로그인 상태(`gh auth login`)가 필요
 
+### Mobile Trigger (권장)
+
+모바일에서 직접 PR을 트리거하려면 GitHub Actions 워크플로우를 사용하세요.
+
+1. self-hosted macOS 러너를 1대 등록합니다.
+2. 저장소 Variables에 아래 값 추가:
+   - `OBSIDIAN_VAULT_PATH`: 러너 머신 기준 Obsidian vault 절대 경로
+   - (선택) `OBSIDIAN_FLEETING_DIR`: 기본 소스 경로를 바꿀 때
+3. 모바일에서 `Actions > Obsidian Sync PR > Run workflow` 실행
+
+워크플로우 파일:
+
+- `.github/workflows/obsidian-sync-pr.yml`
+
+특징:
+
+- Obsidian에서 `content/blog/fleeting`로 동기화
+- 변경이 있을 때만 PR 생성
+- branch: `codex/obsidian-sync-<timestamp>`
+
 ## Analytics (GTM)
 
 Google Tag Manager를 `<head>` script + `<body>` noscript iframe 방식으로 적용합니다.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,47 @@ corepack yarn dev
 ## Commands
 
 ```bash
+yarn sync:obsidian      # Obsidian fleeting 노트 동기화
+yarn sync:obsidian:pr   # 동기화 + 브랜치/커밋/푸시/PR 자동 생성
 yarn dev        # 콘텐츠 생성 + 개발 서버
 yarn build      # 콘텐츠 생성 + 정적 빌드
 yarn typecheck  # route typegen + tsc
 yarn verify     # typecheck + build
 ```
+
+## Obsidian Sync Workflow
+
+Obsidian에서 수정한 fleeting 노트를 블로그 콘텐츠로 반영하고 PR까지 자동 생성할 수 있습니다.
+
+```bash
+# 1) Obsidian 볼트 경로 1회 설정
+export OBSIDIAN_VAULT_PATH="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/<VaultName>"
+
+# 2) 기본 소스(Publish/Fleeting)에서 동기화만
+yarn sync:obsidian
+
+# 3) 동기화 + PR 자동 생성(권장)
+yarn sync:obsidian:pr
+```
+
+옵션 예시:
+
+```bash
+# 변경 미리보기
+yarn sync:obsidian -- --dry-run
+
+# 소스에서 삭제된 노트도 반영
+yarn sync:obsidian:pr -- --prune
+
+# PR 생성 없이 push까지만
+yarn sync:obsidian:pr -- --no-pr
+```
+
+참고:
+
+- 기본 소스 폴더: `Publish/Fleeting`
+- 변경하려면 `OBSIDIAN_FLEETING_DIR` 또는 `--source` 사용
+- `sync:obsidian:pr`는 `gh` CLI 로그인 상태(`gh auth login`)가 필요
 
 ## Analytics (GTM)
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "license": "0BSD",
   "type": "module",
   "scripts": {
+    "sync:obsidian": "node ./scripts/sync-obsidian-fleeting.mjs",
+    "sync:obsidian:pr": "node ./scripts/obsidian-sync-pr.mjs",
     "generate:content": "node ./scripts/generate-content.mjs",
     "dev": "node ./scripts/generate-content.mjs && react-router dev",
     "build": "node ./scripts/generate-content.mjs && react-router build",

--- a/scripts/obsidian-sync-pr.mjs
+++ b/scripts/obsidian-sync-pr.mjs
@@ -1,0 +1,266 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const TARGET_DIR = "content/blog/fleeting";
+
+const USAGE = `
+Obsidian fleeting 동기화 + PR 자동 생성
+
+Usage:
+  yarn sync:obsidian:pr
+  yarn sync:obsidian:pr -- --dry-run
+  yarn sync:obsidian:pr -- --prune --base main
+  yarn sync:obsidian:pr -- --branch codex/obsidian-sync-manual --title "chore: fleeting sync"
+
+Options:
+      --base <branch>   PR base 브랜치 (기본: main)
+      --branch <name>   사용할 작업 브랜치 (기본: codex/obsidian-sync-<timestamp>)
+      --title <text>    PR 제목 (기본: 자동 생성)
+      --no-pr           커밋/푸시까지만 수행하고 PR 생성은 생략
+      --help            도움말 출력
+
+그 외 옵션(--dry-run, --prune, --vault, --source 등)은 sync:obsidian으로 전달됩니다.
+주의: 안전을 위해 --base 브랜치에서만 실행됩니다.
+`.trim();
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: options.stdio || "pipe",
+    cwd: options.cwd || process.cwd(),
+  });
+
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    const details = output ? `\n${output}` : "";
+    throw new Error(`${command} ${args.join(" ")} 실패${details}`);
+  }
+
+  return (result.stdout || "").trim();
+}
+
+function parseArgs(argv) {
+  const options = {
+    base: "main",
+    branch: "",
+    title: "",
+    noPr: false,
+    help: false,
+    syncArgs: [],
+  };
+
+  const readValue = (index, flag) => {
+    const value = argv[index + 1];
+    if (value == null || value.startsWith("-")) {
+      throw new Error(`${flag} 값이 필요합니다.`);
+    }
+    return value;
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    switch (arg) {
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      case "--base":
+        options.base = readValue(i, arg);
+        i += 1;
+        break;
+      case "--branch":
+        options.branch = readValue(i, arg);
+        i += 1;
+        break;
+      case "--title":
+        options.title = readValue(i, arg);
+        i += 1;
+        break;
+      case "--no-pr":
+        options.noPr = true;
+        break;
+      case "--":
+        break;
+      default:
+        options.syncArgs.push(arg);
+        break;
+    }
+  }
+
+  return options;
+}
+
+function nowStamp() {
+  const now = new Date();
+  const yyyy = String(now.getFullYear());
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  const hh = String(now.getHours()).padStart(2, "0");
+  const min = String(now.getMinutes()).padStart(2, "0");
+  const ss = String(now.getSeconds()).padStart(2, "0");
+  return `${yyyy}${mm}${dd}-${hh}${min}${ss}`;
+}
+
+function listChangedPaths() {
+  const output = run("git", ["status", "--porcelain"]);
+  if (!output) {
+    return [];
+  }
+
+  return output
+    .split("\n")
+    .map((line) => line.slice(3).trim())
+    .map((path) => {
+      const arrow = path.indexOf("->");
+      return arrow >= 0 ? path.slice(arrow + 2).trim() : path;
+    })
+    .filter(Boolean);
+}
+
+function isTargetPath(path) {
+  return path === TARGET_DIR || path.startsWith(`${TARGET_DIR}/`);
+}
+
+function currentBranch() {
+  return run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+}
+
+function ensureBaseBranch(base) {
+  const current = currentBranch();
+  if (current !== base) {
+    throw new Error(
+      `현재 브랜치(${current})에서 실행할 수 없습니다. ${base} 브랜치로 이동해서 다시 실행해주세요.`
+    );
+  }
+}
+
+function ensureCleanForScopedCommit() {
+  const paths = listChangedPaths();
+  const outside = paths.filter((path) => !isTargetPath(path));
+  if (outside.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    [
+      "Obsidian PR 자동화는 안전을 위해 content/blog/fleeting 외 변경이 있으면 중단합니다.",
+      "아래 변경을 먼저 정리(커밋/스태시)한 뒤 다시 실행해주세요:",
+      ...outside.map((path) => `- ${path}`),
+    ].join("\n")
+  );
+}
+
+function ensureCommandExists(command) {
+  const result = spawnSync(command, ["--version"], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`${command} 명령을 찾을 수 없습니다. 설치 후 다시 실행해주세요.`);
+  }
+}
+
+function hasTargetChanges() {
+  const output = run("git", ["status", "--porcelain", "--", TARGET_DIR]);
+  return output.length > 0;
+}
+
+function existingPrUrl(branch) {
+  try {
+    const output = run("gh", [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--head",
+      branch,
+      "--json",
+      "url",
+      "--jq",
+      ".[0].url",
+    ]);
+    return output || "";
+  } catch {
+    return "";
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(USAGE);
+    return;
+  }
+
+  ensureCommandExists("git");
+  ensureBaseBranch(options.base);
+
+  ensureCleanForScopedCommit();
+
+  const syncScriptArgs = ["./scripts/sync-obsidian-fleeting.mjs", ...options.syncArgs];
+  run("node", syncScriptArgs, { stdio: "inherit" });
+
+  if (!hasTargetChanges()) {
+    console.log("[skip] 동기화 결과 변경 사항이 없어 PR을 만들지 않습니다.");
+    return;
+  }
+
+  const branch = options.branch || `codex/obsidian-sync-${nowStamp()}`;
+  const prTitle = options.title || `chore: Obsidian fleeting 동기화 (${new Date().toISOString().slice(0, 10)})`;
+  const commitMessage = prTitle;
+  const changedFiles = run("git", ["status", "--porcelain", "--", TARGET_DIR])
+    .split("\n")
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean);
+
+  run("git", ["switch", "-c", branch], { stdio: "inherit" });
+  run("git", ["add", TARGET_DIR], { stdio: "inherit" });
+  run("git", ["commit", "-m", commitMessage], { stdio: "inherit" });
+  run("git", ["push", "-u", "origin", branch], { stdio: "inherit" });
+
+  if (options.noPr) {
+    console.log(`[done] push 완료: ${branch}`);
+    return;
+  }
+
+  ensureCommandExists("gh");
+
+  const openPr = existingPrUrl(branch);
+  if (openPr) {
+    console.log(`[done] 기존 PR 재사용: ${openPr}`);
+    return;
+  }
+
+  const body = [
+    "## 변경 사항",
+    "- Obsidian fleeting 노트를 블로그 콘텐츠로 동기화",
+    "",
+    "## 변경 파일",
+    ...changedFiles.map((file) => `- \`${file}\``),
+    "",
+    "## 체크리스트",
+    "- [x] Obsidian source -> content/blog/fleeting 동기화",
+    "- [ ] 리뷰 후 머지",
+  ].join("\n");
+
+  const prUrl = run("gh", [
+    "pr",
+    "create",
+    "--base",
+    options.base,
+    "--head",
+    branch,
+    "--title",
+    prTitle,
+    "--body",
+    body,
+  ]);
+
+  console.log(`[done] PR 생성 완료: ${prUrl}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/sync-obsidian-fleeting.mjs
+++ b/scripts/sync-obsidian-fleeting.mjs
@@ -1,0 +1,427 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import matter from "gray-matter";
+
+const ROOT = process.cwd();
+const TARGET_DIR = path.join(ROOT, "content", "blog", "fleeting");
+const DEFAULT_SOURCE_SUBDIR = "Publish/Fleeting";
+const DEFAULT_THUMBNAIL = "/thumbnails/hello-world.jpg";
+const DEFAULT_TAG = "Fleeting";
+
+const USAGE = `
+Obsidian -> fleeting 동기화
+
+Usage:
+  yarn sync:obsidian
+  yarn sync:obsidian -- --dry-run
+  yarn sync:obsidian -- --vault "/Users/.../iCloud~md~obsidian/Documents/MyVault"
+  yarn sync:obsidian -- --source "Publish/Fleeting" --prune
+
+Options:
+      --vault <path>     Obsidian 볼트 루트 경로 (기본: env 또는 자동 탐색)
+      --source <path>    볼트 내부 소스 폴더 (기본: "Publish/Fleeting")
+      --dry-run          파일 변경 없이 계획만 출력
+      --prune            소스에서 사라진 동기화 파일 삭제
+  -h, --help             도움말 출력
+
+Environment:
+  OBSIDIAN_VAULT_PATH    볼트 루트 경로
+  OBSIDIAN_FLEETING_DIR  소스 폴더 경로 (기본: Publish/Fleeting)
+`.trim();
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
+}
+
+function quoteYamlString(value) {
+  return JSON.stringify(String(value ?? ""));
+}
+
+function normalizeSegment(value) {
+  return String(value)
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[<>:"|?*]/g, "")
+    .replace(/^\/+|\/+$/g, "");
+}
+
+function normalizePathLike(value) {
+  return String(value)
+    .split("/")
+    .map(normalizeSegment)
+    .filter(Boolean)
+    .join("/");
+}
+
+function normalizeDate(value, fallbackDate) {
+  const fallback = fallbackDate || new Date().toISOString().slice(0, 10);
+  if (value === undefined || value === null || value === "") {
+    return fallback;
+  }
+
+  const parsed = new Date(String(value));
+  if (Number.isNaN(parsed.getTime())) {
+    return fallback;
+  }
+
+  return parsed.toISOString().slice(0, 10);
+}
+
+function normalizeTags(value) {
+  if (Array.isArray(value)) {
+    return value.map(String).map((tag) => tag.trim()).filter(Boolean);
+  }
+
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function extractTitleFromContent(content) {
+  const headingMatch = content.match(/^#\s+(.+)$/m);
+  return headingMatch ? headingMatch[1].trim() : "";
+}
+
+function stripMarkdown(value) {
+  return String(value)
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/[>#*_~|-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildDescription(content) {
+  const plain = stripMarkdown(content);
+  if (!plain) {
+    return "짧은 메모";
+  }
+
+  return plain.slice(0, 120);
+}
+
+function parseArgs(argv) {
+  const options = {
+    vault: "",
+    source: "",
+    dryRun: false,
+    prune: false,
+    help: false,
+  };
+
+  const readValue = (index, flag) => {
+    const value = argv[index + 1];
+    if (value == null || value.startsWith("-")) {
+      throw new Error(`${flag} 값이 필요합니다.`);
+    }
+    return value;
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--":
+        break;
+      case "-h":
+      case "--help":
+        options.help = true;
+        break;
+      case "--vault":
+        options.vault = readValue(i, arg);
+        i += 1;
+        break;
+      case "--source":
+        options.source = readValue(i, arg);
+        i += 1;
+        break;
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--prune":
+        options.prune = true;
+        break;
+      default:
+        throw new Error(`알 수 없는 옵션: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function walkMarkdownFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await walkMarkdownFiles(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && fullPath.toLowerCase().endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function pathExists(value) {
+  try {
+    await fs.access(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function discoverVaultPath() {
+  const defaultObsidianRoot = path.join(
+    os.homedir(),
+    "Library",
+    "Mobile Documents",
+    "iCloud~md~obsidian",
+    "Documents"
+  );
+
+  if (!(await pathExists(defaultObsidianRoot))) {
+    throw new Error(
+      `Obsidian iCloud 경로를 찾을 수 없습니다: ${defaultObsidianRoot}\n--vault 또는 OBSIDIAN_VAULT_PATH를 지정해주세요.`
+    );
+  }
+
+  const entries = await fs.readdir(defaultObsidianRoot, { withFileTypes: true });
+  const vaultCandidates = entries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .map((entry) => path.join(defaultObsidianRoot, entry.name));
+
+  if (vaultCandidates.length === 1) {
+    return vaultCandidates[0];
+  }
+
+  if (vaultCandidates.length === 0) {
+    throw new Error(
+      `Obsidian 볼트가 없습니다: ${defaultObsidianRoot}\n--vault 또는 OBSIDIAN_VAULT_PATH를 지정해주세요.`
+    );
+  }
+
+  throw new Error(
+    [
+      "Obsidian 볼트가 여러 개입니다. --vault 또는 OBSIDIAN_VAULT_PATH를 지정해주세요.",
+      "후보:",
+      ...vaultCandidates.map((candidate) => `- ${candidate}`),
+    ].join("\n")
+  );
+}
+
+async function resolvePaths(options) {
+  const vaultPath =
+    options.vault ||
+    process.env.OBSIDIAN_VAULT_PATH ||
+    (await discoverVaultPath());
+
+  const sourceOption = options.source || process.env.OBSIDIAN_FLEETING_DIR || DEFAULT_SOURCE_SUBDIR;
+  const sourceDir = path.isAbsolute(sourceOption)
+    ? sourceOption
+    : path.join(vaultPath, sourceOption);
+
+  if (!(await pathExists(vaultPath))) {
+    throw new Error(`볼트 경로가 존재하지 않습니다: ${vaultPath}`);
+  }
+  if (!(await pathExists(sourceDir))) {
+    throw new Error(`소스 경로가 존재하지 않습니다: ${sourceDir}`);
+  }
+
+  return {
+    vaultPath,
+    sourceDir,
+  };
+}
+
+function buildFrontmatter({ title, date, description, tags, thumbnail, draft, source }) {
+  const lines = [
+    "---",
+    `title: ${quoteYamlString(title)}`,
+    `date: ${date}`,
+    "type: fleeting",
+    `description: ${quoteYamlString(description)}`,
+    `tags: [${tags.map((tag) => quoteYamlString(tag)).join(", ")}]`,
+    `thumbnail: ${quoteYamlString(thumbnail)}`,
+    `source: ${quoteYamlString(source)}`,
+  ];
+
+  if (draft) {
+    lines.push("draft: true");
+  }
+
+  lines.push("---");
+  return `${lines.join("\n")}\n`;
+}
+
+function ensureTrailingNewline(value) {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+async function readManagedFiles() {
+  if (!(await pathExists(TARGET_DIR))) {
+    return [];
+  }
+
+  const markdownFiles = await walkMarkdownFiles(TARGET_DIR);
+  const managed = [];
+
+  for (const markdownPath of markdownFiles) {
+    const raw = await fs.readFile(markdownPath, "utf8");
+    const { data } = matter(raw);
+    const source = typeof data.source === "string" ? data.source.trim() : "";
+
+    if (source.startsWith("obsidian/")) {
+      managed.push(markdownPath);
+    }
+  }
+
+  return managed;
+}
+
+async function removeEmptyParentDirs(startDir) {
+  let currentDir = startDir;
+  const rootDir = path.resolve(TARGET_DIR);
+
+  while (currentDir.startsWith(rootDir) && currentDir !== rootDir) {
+    const entries = await fs.readdir(currentDir);
+    if (entries.length > 0) {
+      break;
+    }
+    await fs.rmdir(currentDir);
+    currentDir = path.dirname(currentDir);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(USAGE);
+    return;
+  }
+
+  const { vaultPath, sourceDir } = await resolvePaths(options);
+  const sourceFiles = await walkMarkdownFiles(sourceDir);
+
+  console.log(`[sync] vault: ${vaultPath}`);
+  console.log(`[sync] source: ${sourceDir}`);
+  console.log(`[sync] target: ${TARGET_DIR}`);
+  console.log(`[sync] source files: ${sourceFiles.length}`);
+
+  const generatedTargetPaths = new Set();
+  const stats = {
+    created: 0,
+    updated: 0,
+    unchanged: 0,
+    removed: 0,
+  };
+
+  for (const sourcePath of sourceFiles) {
+    const raw = await fs.readFile(sourcePath, "utf8");
+    const fileStat = await fs.stat(sourcePath);
+    const { data, content } = matter(raw);
+
+    const relativeSourcePath = toPosix(path.relative(sourceDir, sourcePath));
+    const relativeWithoutExt = relativeSourcePath.replace(/\.md$/i, "");
+    const fallbackSlug = normalizePathLike(relativeWithoutExt.replace(/\/index$/i, ""));
+    const explicitSlug = normalizePathLike(String(data.slug || ""));
+    const slug = explicitSlug || fallbackSlug;
+
+    if (!slug) {
+      console.warn(`[skip] slug을 만들 수 없어 건너뜀: ${relativeSourcePath}`);
+      continue;
+    }
+
+    const fallbackTitle = extractTitleFromContent(content) || path.basename(relativeWithoutExt);
+    const title = String(data.title || fallbackTitle).trim();
+    const description = String(data.description || buildDescription(content)).trim();
+    const date = normalizeDate(data.date, fileStat.mtime.toISOString().slice(0, 10));
+    const tags = normalizeTags(data.tags);
+    const thumbnail = String(data.thumbnail || DEFAULT_THUMBNAIL).trim();
+    const draft = Boolean(data.draft);
+    const source = `obsidian/${relativeSourcePath}`;
+
+    const frontmatter = buildFrontmatter({
+      title: title || fallbackTitle,
+      date,
+      description: description || "짧은 메모",
+      tags: tags.length > 0 ? tags : [DEFAULT_TAG],
+      thumbnail: thumbnail.startsWith("/") ? thumbnail : DEFAULT_THUMBNAIL,
+      draft,
+      source,
+    });
+    const body = ensureTrailingNewline(content.trim() ? content.trim() : "## 메모\n");
+    const nextMarkdown = `${frontmatter}\n${body}`;
+
+    const targetPath = path.join(TARGET_DIR, ...slug.split("/"), "index.md");
+    generatedTargetPaths.add(path.resolve(targetPath));
+
+    const existed = await pathExists(targetPath);
+    const prevMarkdown = existed ? await fs.readFile(targetPath, "utf8") : "";
+
+    if (prevMarkdown === nextMarkdown) {
+      stats.unchanged += 1;
+      continue;
+    }
+
+    if (!options.dryRun) {
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, nextMarkdown, "utf8");
+    }
+
+    if (existed) {
+      stats.updated += 1;
+      console.log(`[update] ${path.relative(ROOT, targetPath)}`);
+    } else {
+      stats.created += 1;
+      console.log(`[create] ${path.relative(ROOT, targetPath)}`);
+    }
+  }
+
+  if (options.prune) {
+    const managedFiles = await readManagedFiles();
+    for (const managedPath of managedFiles) {
+      const normalizedManagedPath = path.resolve(managedPath);
+      if (generatedTargetPaths.has(normalizedManagedPath)) {
+        continue;
+      }
+
+      if (!options.dryRun) {
+        await fs.unlink(managedPath);
+        await removeEmptyParentDirs(path.dirname(managedPath));
+      }
+
+      stats.removed += 1;
+      console.log(`[remove] ${path.relative(ROOT, managedPath)}`);
+    }
+  }
+
+  console.log(
+    `[done] created=${stats.created}, updated=${stats.updated}, unchanged=${stats.unchanged}, removed=${stats.removed}${options.dryRun ? " (dry-run)" : ""}`
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## 배경
- 현재는 Obsidian 수정 후 수동으로 git add/commit/push/PR을 해야 했습니다.
- 원하는 흐름은 Obsidian 수정 직후 원격 PR까지 바로 트리거되는 형태입니다.

## 변경 사항
- `scripts/sync-obsidian-fleeting.mjs` 추가
  - Obsidian iCloud 볼트의 `Publish/Fleeting`(기본값)에서 `content/blog/fleeting`로 동기화
  - frontmatter(`type: fleeting`, `source: obsidian/...`) 자동 보정
  - `--dry-run`, `--prune`, `--vault`, `--source` 지원
- `scripts/obsidian-sync-pr.mjs` 추가
  - `sync:obsidian` 실행 후 변경 감지
  - 브랜치 생성 -> 커밋 -> 푸시 -> PR 생성 자동화
  - 안전장치: `content/blog/fleeting` 외 변경이 있으면 중단
  - 안전장치: base 브랜치(기본 `main`)에서만 실행
- `package.json` 스크립트 추가
  - `sync:obsidian`
  - `sync:obsidian:pr`
- `README.md`에 실제 운영 워크플로우 및 명령 예시 추가

## 사용 예시
```bash
export OBSIDIAN_VAULT_PATH="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/<VaultName>"
corepack yarn sync:obsidian:pr
```

## 검증
- `node --check scripts/sync-obsidian-fleeting.mjs`
- `node --check scripts/obsidian-sync-pr.mjs`
- `corepack yarn sync:obsidian -- --help`
- `corepack yarn sync:obsidian:pr -- --help`
- `corepack yarn sync:obsidian:pr -- --dry-run` 시 base 브랜치 가드 메시지 확인
