### PR TITLE
[codex] dev 환경 콘텐츠 갱신 문제 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ corepack yarn dev
 ```bash
 yarn new:post   # 새 글 스캐폴딩
 yarn sync:obsidian # Obsidian fleeting 노트 동기화
-yarn dev        # 콘텐츠 생성 + 개발 서버
+yarn dev        # 콘텐츠 생성 + 개발 서버(content 변경 자동 반영)
 yarn build      # 콘텐츠 생성 + 정적 빌드
 yarn typecheck  # route typegen + tsc
 yarn verify     # typecheck + build

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rehype-autolink-headings": "^7.1.0",
     "rehype-katex": "^7.0.1",
     "rehype-prism-plus": "^2.0.1",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
@@ -53,6 +54,7 @@
     "sharp": "^0.34.5",
     "typescript": "^5.9.3",
     "vite": "^6.4.1",
+    "vite-plugin-watch-and-run": "^1.8.0",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "packageManager": "yarn@4.12.0",

--- a/scripts/generate-content.mjs
+++ b/scripts/generate-content.mjs
@@ -7,6 +7,7 @@ import matter from "gray-matter";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeKatex from "rehype-katex";
 import rehypePrism from "rehype-prism-plus";
+import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import rehypeStringify from "rehype-stringify";
 import { remark } from "remark";
@@ -671,7 +672,8 @@ async function main() {
       await remark()
         .use(remarkGfm)
         .use(remarkMath)
-        .use(remarkRehype)
+        .use(remarkRehype, { allowDangerousHtml: true })
+        .use(rehypeRaw)
         .use(rehypeSlug)
         .use(collectHeadings(headingRecords))
         .use(rewriteRelativeUrls(path.posix.dirname(relativePath)))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,29 @@
+import path from "node:path";
+
 import { reactRouter } from "@react-router/dev/vite";
 import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
 import { defineConfig } from "vite";
+import { watchAndRun } from "vite-plugin-watch-and-run";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [reactRouter(), vanillaExtractPlugin(), tsconfigPaths()],
+  plugins: [
+    watchAndRun([
+      {
+        name: "content",
+        watch: [
+          path.resolve("content/blog/**/*"),
+          path.resolve("static/**/*"),
+          path.resolve("site.config.json"),
+        ],
+        run: "node ./scripts/generate-content.mjs",
+        delay: 200,
+      },
+    ]),
+    reactRouter(),
+    vanillaExtractPlugin(),
+    tsconfigPaths(),
+  ],
   build: {
     // Prevent route-level CSS chunking which can cause a flash of unstyled content
     // during client-side navigations on slow networks.

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kitql/helpers@npm:0.8.13":
+  version: 0.8.13
+  resolution: "@kitql/helpers@npm:0.8.13"
+  dependencies:
+    esm-env: "npm:^1.2.2"
+  checksum: 10c0/54a43a8b44eab1c5cd91071592a3ef902468e872988fe07ae914424fc206a6d08f7167c3451f49b166259b56366ef6ec2b43d744f5eba6d1f98258f29d0486c1
+  languageName: node
+  linkType: hard
+
 "@mjackson/node-fetch-server@npm:^0.2.0":
   version: 0.2.0
   resolution: "@mjackson/node-fetch-server@npm:0.2.0"
@@ -2223,6 +2232,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esm-env@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "esm-env@npm:1.2.2"
+  checksum: 10c0/3d25c973f2fd69c25ffff29c964399cea573fe10795ecc1d26f6f957ce0483d3254e1cceddb34bf3296a0d7b0f1d53a28992f064ba509dfe6366751e752c4166
+  languageName: node
+  linkType: hard
+
 "esprima@npm:^4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
@@ -2396,6 +2412,7 @@ __metadata:
     rehype-autolink-headings: "npm:^7.1.0"
     rehype-katex: "npm:^7.0.1"
     rehype-prism-plus: "npm:^2.0.1"
+    rehype-raw: "npm:^7.0.0"
     rehype-slug: "npm:^6.0.0"
     rehype-stringify: "npm:^10.0.1"
     remark: "npm:^15.0.1"
@@ -2406,6 +2423,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     unist-util-visit: "npm:^5.0.0"
     vite: "npm:^6.4.1"
+    vite-plugin-watch-and-run: "npm:^1.8.0"
     vite-tsconfig-paths: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
@@ -2548,6 +2566,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-raw@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "hast-util-raw@npm:9.1.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    "@ungap/structured-clone": "npm:^1.0.0"
+    hast-util-from-parse5: "npm:^8.0.0"
+    hast-util-to-parse5: "npm:^8.0.0"
+    html-void-elements: "npm:^3.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    parse5: "npm:^7.0.0"
+    unist-util-position: "npm:^5.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/d0d909d2aedecef6a06f0005cfae410d6475e6e182d768bde30c3af9fcbbe4f9beb0522bdc21d0679cb3c243c0df40385797ed255148d68b3d3f12e82d12aacc
+  languageName: node
+  linkType: hard
+
 "hast-util-to-html@npm:^9.0.0":
   version: 9.0.5
   resolution: "hast-util-to-html@npm:9.0.5"
@@ -2564,6 +2603,21 @@ __metadata:
     stringify-entities: "npm:^4.0.0"
     zwitch: "npm:^2.0.4"
   checksum: 10c0/b7a08c30bab4371fc9b4a620965c40b270e5ae7a8e94cf885f43b21705179e28c8e43b39c72885d1647965fb3738654e6962eb8b58b0c2a84271655b4d748836
+  languageName: node
+  linkType: hard
+
+"hast-util-to-parse5@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "hast-util-to-parse5@npm:8.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    property-information: "npm:^7.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/8e8a1817c7ff8906ac66e7201b1b8d19d9e1b705e695a6e71620270d498d982ec1ecc0e227bd517f723e91e7fdfb90ef75f9ae64d14b3b65239a7d5e1194d7dd
   languageName: node
   linkType: hard
 
@@ -3803,17 +3857,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:4.0.3, picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "picomatch@npm:4.0.3"
+  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
   languageName: node
   linkType: hard
 
@@ -4034,6 +4088,17 @@ __metadata:
     unist-util-filter: "npm:^5.0.1"
     unist-util-visit: "npm:^5.1.0"
   checksum: 10c0/d87e2bb91e4b45a105ce63d4598a23ad809feac48ee80d9d5f533d311ec89442040aadad9edd85e9ae12fc8eb8e0737a8da4c7fcb1dea98be971ae77f7ec7f7e
+  languageName: node
+  linkType: hard
+
+"rehype-raw@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "rehype-raw@npm:7.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hast-util-raw: "npm:^9.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/1435b4b6640a5bc3abe3b2133885c4dbff5ef2190ef9cfe09d6a63f74dd7d7ffd0cede70603278560ccf1acbfb9da9faae4b68065a28bc5aa88ad18e40f32d52
   languageName: node
   linkType: hard
 
@@ -4849,6 +4914,18 @@ __metadata:
   bin:
     vite-node: vite-node.mjs
   checksum: 10c0/6ceca67c002f8ef6397d58b9539f80f2b5d79e103a18367288b3f00a8ab55affa3d711d86d9112fce5a7fa658a212a087a005a045eb8f4758947dd99af2a6c6b
+  languageName: node
+  linkType: hard
+
+"vite-plugin-watch-and-run@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "vite-plugin-watch-and-run@npm:1.8.0"
+  dependencies:
+    "@kitql/helpers": "npm:0.8.13"
+    picomatch: "npm:4.0.3"
+  peerDependencies:
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/818b635942f63520464135338e9ce244e4791becdb3d83602e3f273bbdb5029ee7c93375960a4193971a36f9f375b940b3a498a7c53b883b367291046ee1d43a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 요약

- 커스텀 watcher 대신 `vite-plugin-watch-and-run`으로 `react-router dev` 실행 중 콘텐츠 생성 스크립트를 다시 실행합니다.
- `content/blog`, `static`, `site.config.json` 변경 시 `scripts/generate-content.mjs`가 다시 실행되어 `app/generated/*.json`과 public 산출물이 갱신됩니다.
- Markdown 안의 raw HTML `<img>` 태그가 생성 HTML에서 사라지지 않도록 `rehype-raw`를 콘텐츠 파이프라인에 추가했습니다.
- raw HTML 이미지의 상대 경로도 기존 이미지 경로 규칙대로 `/content/blog/...` URL로 변환되도록 했습니다.
- dev 명령 설명을 현재 동작에 맞게 업데이트했습니다.

## 원인

기존 dev 스크립트는 서버 시작 전에 `scripts/generate-content.mjs`를 한 번만 실행했습니다. 그래서 글을 저장해도 `app/generated/*.json`이 갱신되지 않았고, React Router/Vite 입장에서는 바뀐 route module이 없어 HMR/HDR로 반영할 변경을 찾지 못했습니다.

또 raw HTML은 `remark-rehype` 단계에서 HTML AST로 파싱되지 않아 `<img src="./image0.jpg">`가 생성 HTML에 남지 않았습니다. 이 때문에 이미지 파일은 `public/content/blog/...`에 있어도 localhost 페이지에서는 보이지 않았습니다.

## 검증

- `corepack yarn typecheck`
- pre-commit `lint-staged`에서 `npm run typecheck` 통과
- dev 서버에서 Markdown probe 추가/삭제 시 `vite-plugin-watch-and-run`이 `scripts/generate-content.mjs`를 실행하고 `app/generated/*.json`이 갱신되는 것 확인
- 로컬에서 `/content/blog/article/history-of-studying-abstraction/image0.jpg`가 `200 OK`로 응답하는 것 확인